### PR TITLE
feat: add C404 worker dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,11 @@
       "name": "kk-dash",
       "version": "0.0.0",
       "dependencies": {
+        "bootstrap": "^5.3.7",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.0",
+        "typescript": "^5.9.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -1020,6 +1023,17 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.30",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.30.tgz",
@@ -1477,6 +1491,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bootstrap": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
+      "integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1602,6 +1635,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2475,6 +2517,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.0.tgz",
+      "integrity": "sha512-r15M3+LHKgM4SOapNmsH3smAizWds1vJ0Z9C4mWaKnT9/wD7+d/0jYcj6LmOvonkrO4Rgdyp4KQ/29gWN2i1eg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.0.tgz",
+      "integrity": "sha512-ntInsnDVnVRdtSu6ODmTQ41cbluak/ENeTif7GBce0L6eztFg6/e1hXAysFQI8X25C8ipKmT9cClbJwxx3Kaqw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2540,6 +2620,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2628,6 +2714,19 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "bootstrap": "^5.3.7",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.0",
+    "typescript": "^5.9.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,20 +1,5 @@
-import React from "react";
-import Navbar from "./Components/Navbar";
-import Timesheet from "./Pages/Timesheet";
+import AppRoutes from './routes/AppRoutes';
 
-function App() {
-  const handleSignOut = () => {
-    alert("Signing out...");
-  };
-
-  return (
-    <>
-      <div>
-        <Navbar username="John Doe" onSignOut={handleSignOut} />
-        <Timesheet />
-      </div>
-    </>
-  );
+export default function App() {
+  return <AppRoutes />;
 }
-
-export default App;

--- a/src/components/DashboardCard.tsx
+++ b/src/components/DashboardCard.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+
+interface Props {
+  title: string;
+  children: ReactNode;
+  actionLabel?: string;
+  actionTo?: string;
+}
+
+export default function DashboardCard({ title, children, actionLabel, actionTo }: Props) {
+  return (
+    <div className="card h-100">
+      <div className="card-header d-flex justify-content-between align-items-center">
+        <h2 className="h6 m-0">{title}</h2>
+        {actionLabel && actionTo && (
+          <Link to={actionTo} className="btn btn-sm btn-primary" aria-label={actionLabel}>
+            {actionLabel}
+          </Link>
+        )}
+      </div>
+      <div className="card-body">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,43 @@
+import { NavLink } from 'react-router-dom';
+
+export default function Sidebar() {
+  const links = [
+    { to: '/c404/dashboard', label: 'Dashboard' },
+    { to: '/available-shifts', label: 'Available Shifts' },
+    { to: '/my-bookings', label: 'My Bookings' },
+    { to: '/timesheets', label: 'Timesheets' },
+    { to: '/messages', label: 'Communications' },
+    { to: '/payslips', label: 'Payslips' },
+    { to: '#', label: 'Learning & Development' },
+    { to: '#', label: 'Reviews' },
+    { to: '#', label: 'Documents & Notes' },
+    { to: '/profile-compliance', label: 'Profile & Compliance' },
+  ];
+
+  return (
+    <aside
+      className="offcanvas-md offcanvas-start bg-light border-end" 
+      tabIndex={-1}
+      id="sidebarMenu"
+      aria-labelledby="sidebarMenuLabel"
+    >
+      <div className="offcanvas-body p-0 d-flex flex-column h-100">
+        <div className="p-3 border-bottom d-md-none">
+          <h5 id="sidebarMenuLabel">Menu</h5>
+        </div>
+        <ul className="nav nav-pills flex-column mb-auto">
+          {links.map(link => (
+            <li className="nav-item" key={link.to}>
+              <NavLink
+                to={link.to}
+                className={({ isActive }) => 'nav-link' + (isActive ? ' active' : '')}
+              >
+                {link.label}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -1,0 +1,42 @@
+import { Link } from 'react-router-dom';
+
+interface Props {
+  notifications: number;
+}
+
+export default function Topbar({ notifications }: Props) {
+  return (
+    <nav className="navbar navbar-light bg-white border-bottom px-3">
+      <button
+        className="btn btn-outline-secondary d-md-none me-2"
+        type="button"
+        data-bs-toggle="offcanvas"
+        data-bs-target="#sidebarMenu"
+        aria-label="Open menu"
+      >
+        ☰
+      </button>
+      <form className="d-none d-md-inline-flex me-auto" role="search" aria-label="Search">
+        <input className="form-control" type="search" placeholder="Search" aria-label="Search input" />
+      </form>
+      <div className="ms-auto d-flex align-items-center gap-3">
+        <button className="btn position-relative" aria-label="Notifications">
+          <span role="img" aria-label="bell">🔔</span>
+          {notifications > 0 && (
+            <span className="badge bg-danger position-absolute top-0 start-100 translate-middle">
+              {notifications}
+            </span>
+          )}
+        </button>
+        <div className="dropdown">
+          <button className="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-label="User menu">
+            User
+          </button>
+          <ul className="dropdown-menu dropdown-menu-end">
+            <li><Link className="dropdown-item" to="#">Sign out</Link></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/WeekPlanner.tsx
+++ b/src/components/WeekPlanner.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react';
+import { Booking } from '../features/c404/types';
+import { getPlannerWeek } from '../features/c404/c404Api';
+
+const dayNames = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+function startOfWeek(d: Date) {
+  const date = new Date(d);
+  const day = date.getDay();
+  const diff = (day === 0 ? -6 : 1) - day;
+  date.setDate(date.getDate() + diff);
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+function addDays(d: Date, days: number) {
+  const date = new Date(d);
+  date.setDate(date.getDate() + days);
+  return date;
+}
+
+export default function WeekPlanner() {
+  const [start, setStart] = useState(() => startOfWeek(new Date()));
+  const [bookings, setBookings] = useState<Booking[]>([]);
+  const [selected, setSelected] = useState<Booking | null>(null);
+
+  useEffect(() => {
+    getPlannerWeek(start.toISOString().split('T')[0]).then(setBookings);
+  }, [start]);
+
+  const handlePrev = () => setStart(s => addDays(s, -7));
+  const handleNext = () => setStart(s => addDays(s, 7));
+
+  const weekDays = Array.from({ length: 7 }, (_, i) => addDays(start, i));
+  const todayIso = new Date().toISOString().split('T')[0];
+
+  return (
+    <div className="card h-100">
+      <div className="card-header d-flex justify-content-between align-items-center">
+        <h2 className="h6 m-0">My Planner</h2>
+        <div>
+          <button className="btn btn-sm btn-outline-secondary me-1" onClick={handlePrev} aria-label="Previous week">&lt;</button>
+          <button className="btn btn-sm btn-outline-secondary" onClick={handleNext} aria-label="Next week">&gt;</button>
+        </div>
+      </div>
+      <div className="card-body">
+        <div className="row row-cols-7 g-2 d-none d-md-flex">
+          {weekDays.map((day, idx) => {
+            const iso = day.toISOString().split('T')[0];
+            const dayBookings = bookings.filter(b => b.date === iso);
+            return (
+              <div className="col" key={idx}>
+                <div className={'border rounded p-2 h-100 ' + (iso === todayIso ? 'bg-light' : '')}>
+                  <div className="fw-semibold">{dayNames[idx]} {day.getDate()}</div>
+                  {dayBookings.map(b => (
+                    <button key={b.id} className="btn btn-link p-0 text-start" onClick={() => setSelected(b)} aria-label={`View ${b.site} booking`}>
+                      {b.role} {b.start}-{b.end}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <ul className="list-group d-md-none">
+          {weekDays.map((day, idx) => {
+            const iso = day.toISOString().split('T')[0];
+            const dayBookings = bookings.filter(b => b.date === iso);
+            return (
+              <li className="list-group-item" key={idx}>
+                <div className="fw-semibold">{dayNames[idx]} {day.getDate()}</div>
+                {dayBookings.map(b => (
+                  <button key={b.id} className="btn btn-link p-0 text-start" onClick={() => setSelected(b)} aria-label={`View ${b.site} booking`}>
+                    {b.role} {b.start}-{b.end}
+                  </button>
+                ))}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+      {selected && (
+        <div className="offcanvas offcanvas-end show" style={{ visibility: 'visible' }}>
+          <div className="offcanvas-header">
+            <h5 className="offcanvas-title">{selected.site}</h5>
+            <button type="button" className="btn-close" aria-label="Close" onClick={() => setSelected(null)}></button>
+          </div>
+          <div className="offcanvas-body">
+            <p><strong>{selected.role}</strong></p>
+            <p>{selected.date} {selected.start}-{selected.end}</p>
+            {selected.contactName && <p>Contact: {selected.contactName} {selected.contactPhone}</p>}
+            <div className="d-grid gap-2">
+              <button className="btn btn-secondary" aria-label="View instructions">View instructions</button>
+              <a className="btn btn-primary" href={`/timesheets?prefill=${selected.id}`} aria-label="Submit timesheet">Submit timesheet</a>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/c404/C404Dashboard.tsx
+++ b/src/features/c404/C404Dashboard.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Sidebar from '../../components/Sidebar';
+import Topbar from '../../components/Topbar';
+import DashboardCard from '../../components/DashboardCard';
+import WeekPlanner from '../../components/WeekPlanner';
+import {
+  Booking,
+  ShiftAdvert,
+  MessagePreview,
+  ComplianceSummary,
+  Payslip,
+} from './types';
+import {
+  getNextBooking,
+  getShiftAdverts,
+  getTimesheetSummary,
+  getMessagePreviews,
+  getComplianceSummary,
+  getRecentPayslips,
+} from './c404Api';
+
+export default function C404Dashboard() {
+  const [nextBooking, setNextBooking] = useState<Booking | null>(null);
+  const [adverts, setAdverts] = useState<ShiftAdvert[]>([]);
+  const [timesheets, setTimesheets] = useState({ awaitingClient: 0, clientApproved: 0, finalised: 0 });
+  const [messages, setMessages] = useState<MessagePreview[]>([]);
+  const [compliance, setCompliance] = useState<ComplianceSummary | null>(null);
+  const [payslips, setPayslips] = useState<Payslip[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const [nb, sh, ts, msg, comp, pay] = await Promise.all([
+        getNextBooking(),
+        getShiftAdverts(3),
+        getTimesheetSummary(),
+        getMessagePreviews(3),
+        getComplianceSummary(),
+        getRecentPayslips(2),
+      ]);
+      setNextBooking(nb);
+      setAdverts(sh);
+      setTimesheets(ts);
+      setMessages(msg);
+      setCompliance(comp);
+      setPayslips(pay);
+      setLoading(false);
+    })();
+  }, []);
+
+  const handleAccept = (id: string) => {
+    setAdverts(a => a.filter(s => s.id !== id));
+  };
+
+  if (loading) {
+    return <div className="p-3">Loading...</div>;
+  }
+
+  return (
+    <div className="d-flex">
+      <Sidebar />
+      <div className="flex-grow-1">
+        <Topbar notifications={timesheets.awaitingClient} />
+        <main className="container-fluid py-3">
+          <h1 className="h4 mb-3">C404 Dashboard</h1>
+          <div className="row g-3">
+            <div className="col-12 col-md-4">
+              <DashboardCard
+                title="My Next Booking"
+                actionLabel="View details"
+                actionTo={nextBooking ? `/my-bookings/${nextBooking.id}` : '/my-bookings'}
+              >
+                {nextBooking ? (
+                  <div>
+                    <div>{nextBooking.date} {nextBooking.start}-{nextBooking.end}</div>
+                    <div>{nextBooking.site}</div>
+                    <div>{nextBooking.role}</div>
+                  </div>
+                ) : (
+                  <div>No bookings yet — check Available Shifts</div>
+                )}
+              </DashboardCard>
+            </div>
+            <div className="col-12 col-md-4">
+              <DashboardCard title="Available Shifts near me" actionLabel="View all" actionTo="/available-shifts">
+                {adverts.length ? (
+                  <ul className="list-unstyled mb-0">
+                    {adverts.map(ad => (
+                      <li key={ad.id} className="mb-2">
+                        <div>{ad.site} - {ad.role}</div>
+                        <div>{ad.date} {ad.start}-{ad.end}</div>
+                        <button
+                          className="btn btn-sm btn-success mt-1"
+                          onClick={() => handleAccept(ad.id)}
+                          aria-label={`Accept shift at ${ad.site}`}
+                        >
+                          Accept
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <div>No shifts available today. Try changing filters.</div>
+                )}
+              </DashboardCard>
+            </div>
+            <div className="col-12 col-md-4">
+              <DashboardCard title="Approvals status" actionLabel="View" actionTo="/timesheets">
+                <div className="d-flex flex-column gap-1">
+                  <Link to="/timesheets?status=Awaiting%20Client" className="text-decoration-none" aria-label="Awaiting client timesheets">
+                    {timesheets.awaitingClient} Awaiting client
+                  </Link>
+                  <Link to="/timesheets?status=Client%20Approved" className="text-decoration-none" aria-label="Client approved timesheets">
+                    {timesheets.clientApproved} Approved
+                  </Link>
+                  <Link to="/timesheets?status=Finalised" className="text-decoration-none" aria-label="Finalised timesheets">
+                    {timesheets.finalised} Finalised
+                  </Link>
+                </div>
+              </DashboardCard>
+            </div>
+            <div className="col-12">
+              <WeekPlanner />
+            </div>
+            <div className="col-12 col-md-4">
+              <DashboardCard title="Messages" actionLabel="Open inbox" actionTo="/messages">
+                {messages.length ? (
+                  <ul className="list-unstyled mb-0">
+                    {messages.map(m => (
+                      <li key={m.id} tabIndex={0} className="mb-2" aria-label={m.subject}>
+                        <span className={m.unread ? 'fw-bold' : ''}>{m.subject}</span>
+                        <div className="small text-muted">{m.lastFrom}</div>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <div>No messages</div>
+                )}
+              </DashboardCard>
+            </div>
+            <div className="col-12 col-md-4">
+              <DashboardCard title="Compliance status" actionLabel="Update docs" actionTo="/profile-compliance">
+                {compliance && (
+                  <div>
+                    <span className="badge bg-success me-1" aria-label={`OK ${compliance.ok}`}>OK {compliance.ok}</span>
+                    <span className="badge bg-warning text-dark me-1" aria-label={`WARN ${compliance.warn}`}>WARN {compliance.warn}</span>
+                    <span className="badge bg-danger" aria-label={`FAIL ${compliance.fail}`}>FAIL {compliance.fail}</span>
+                  </div>
+                )}
+              </DashboardCard>
+            </div>
+            <div className="col-12 col-md-4">
+              <DashboardCard title="Recent payslips" actionLabel="View all" actionTo="/payslips">
+                {payslips.length ? (
+                  <ul className="list-unstyled mb-0">
+                    {payslips.map(p => (
+                      <li key={p.id}><a href={p.url}>{p.period}</a></li>
+                    ))}
+                  </ul>
+                ) : (
+                  <div>No payslips</div>
+                )}
+              </DashboardCard>
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/features/c404/c404Api.ts
+++ b/src/features/c404/c404Api.ts
@@ -1,0 +1,52 @@
+import {
+  Booking,
+  ShiftAdvert,
+  MessagePreview,
+  ComplianceSummary,
+  Payslip,
+} from './types';
+import {
+  nextBooking,
+  shiftAdverts,
+  timesheetSummary,
+  messagePreviews,
+  complianceSummary,
+  payslips,
+  timesheetRows,
+} from './mock';
+
+export function getNextBooking(): Promise<Booking | null> {
+  return Promise.resolve(nextBooking);
+}
+
+export function getShiftAdverts(limit = 3): Promise<ShiftAdvert[]> {
+  return Promise.resolve(shiftAdverts.slice(0, limit));
+}
+
+export function getTimesheetSummary(): Promise<{ awaitingClient: number; clientApproved: number; finalised: number; }> {
+  return Promise.resolve(timesheetSummary);
+}
+
+export function getPlannerWeek(startIso: string): Promise<Booking[]> {
+  // For mock just return bookings for the week ignoring start
+  return Promise.resolve([nextBooking, ...timesheetRows.map(r => ({
+    id: r.id,
+    date: r.date,
+    start: '08:00',
+    end: '16:00',
+    site: r.site,
+    role: 'HCA',
+  }))]);
+}
+
+export function getMessagePreviews(limit = 3): Promise<MessagePreview[]> {
+  return Promise.resolve(messagePreviews.slice(0, limit));
+}
+
+export function getComplianceSummary(): Promise<ComplianceSummary> {
+  return Promise.resolve(complianceSummary);
+}
+
+export function getRecentPayslips(limit = 2): Promise<Payslip[]> {
+  return Promise.resolve(payslips.slice(0, limit));
+}

--- a/src/features/c404/mock.ts
+++ b/src/features/c404/mock.ts
@@ -1,0 +1,54 @@
+import { Booking, ShiftAdvert, MessagePreview, ComplianceSummary, Payslip, TimesheetRow } from './types';
+
+export const nextBooking: Booking = {
+  id: 'b1',
+  date: new Date().toISOString().split('T')[0],
+  start: '08:00',
+  end: '16:00',
+  site: 'Sunrise Care Home',
+  role: 'HCA',
+  contactName: 'Alice Manager',
+  contactPhone: '0123456789',
+};
+
+export const shiftAdverts: ShiftAdvert[] = [
+  { id: 's1', site: 'Oakview Hospital', role: 'RN', date: new Date().toISOString().split('T')[0], start: '09:00', end: '17:00', distanceKm: 5 },
+  { id: 's2', site: 'Maple Lodge', role: 'HCA', date: new Date(Date.now()+86400000).toISOString().split('T')[0], start: '07:00', end: '15:00', distanceKm: 8 },
+  { id: 's3', site: 'Elm Clinic', role: 'HCA', date: new Date(Date.now()+2*86400000).toISOString().split('T')[0], start: '20:00', end: '08:00', distanceKm: 12 },
+];
+
+export const timesheetRows: TimesheetRow[] = [
+  { id: 't1', date: new Date().toISOString().split('T')[0], site: 'Sunrise Care Home', hours: 8, status: 'Awaiting Client' },
+  { id: 't2', date: new Date(Date.now()-86400000).toISOString().split('T')[0], site: 'Oakview Hospital', hours: 8, status: 'Client Approved' },
+  { id: 't3', date: new Date(Date.now()-2*86400000).toISOString().split('T')[0], site: 'Maple Lodge', hours: 8, status: 'Finalised' },
+];
+
+export const messagePreviews: MessagePreview[] = [
+  { id: 'm1', subject: 'Shift confirmation', lastFrom: 'Scheduler', lastAt: new Date().toISOString(), unread: true },
+  { id: 'm2', subject: 'Policy update', lastFrom: 'HR', lastAt: new Date(Date.now()-86400000).toISOString(), unread: false },
+  { id: 'm3', subject: 'Payslip ready', lastFrom: 'Payroll', lastAt: new Date(Date.now()-2*86400000).toISOString(), unread: false },
+];
+
+export const complianceSummary: ComplianceSummary = {
+  ok: 3,
+  warn: 1,
+  fail: 1,
+  items: [
+    { name: 'DBS', status: 'OK' },
+    { name: 'Immunisation', status: 'WARN', due: new Date(Date.now()+30*86400000).toISOString() },
+    { name: 'Training', status: 'FAIL' },
+    { name: 'Right to Work', status: 'OK' },
+    { name: 'References', status: 'OK' },
+  ],
+};
+
+export const payslips: Payslip[] = [
+  { id: 'p1', period: 'Jun 2025', url: '#' },
+  { id: 'p2', period: 'May 2025', url: '#' },
+];
+
+export const timesheetSummary = {
+  awaitingClient: 1,
+  clientApproved: 1,
+  finalised: 1,
+};

--- a/src/features/c404/types.ts
+++ b/src/features/c404/types.ts
@@ -1,0 +1,49 @@
+export type Booking = {
+  id: string;
+  date: string; // ISO
+  start: string; // "08:00"
+  end: string; // "16:00"
+  site: string;
+  role: string; // e.g. "HCA"
+  contactName?: string;
+  contactPhone?: string;
+};
+
+export type ShiftAdvert = {
+  id: string;
+  site: string;
+  role: string;
+  date: string; // ISO
+  start: string;
+  end: string;
+  distanceKm?: number;
+};
+
+export type TimesheetStatus = 'Awaiting Client' | 'Client Approved' | 'Finalised';
+
+export type TimesheetRow = {
+  id: string;
+  date: string;
+  site: string;
+  hours: number;
+  status: TimesheetStatus;
+};
+
+export type MessagePreview = {
+  id: string;
+  subject: string;
+  lastFrom: string;
+  lastAt: string; // ISO
+  unread: boolean;
+};
+
+export type ComplianceSummary = {
+  ok: number; warn: number; fail: number; // counts
+  items: { name: string; status: 'OK'|'WARN'|'FAIL'; due?: string }[];
+};
+
+export type Payslip = {
+  id: string;
+  period: string; // "Jun 2025"
+  url: string;
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,11 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import './index.css';
+import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />
   </StrictMode>,
-)
+);

--- a/src/pages/AvailableShifts.tsx
+++ b/src/pages/AvailableShifts.tsx
@@ -1,0 +1,3 @@
+export default function AvailableShifts() {
+  return <h2>Available Shifts</h2>;
+}

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -1,0 +1,3 @@
+export default function Messages() {
+  return <h2>Messages</h2>;
+}

--- a/src/pages/MyBookings.tsx
+++ b/src/pages/MyBookings.tsx
@@ -1,0 +1,3 @@
+export default function MyBookings() {
+  return <h2>My Bookings</h2>;
+}

--- a/src/pages/Payslips.tsx
+++ b/src/pages/Payslips.tsx
@@ -1,0 +1,3 @@
+export default function Payslips() {
+  return <h2>Payslips</h2>;
+}

--- a/src/pages/ProfileCompliance.tsx
+++ b/src/pages/ProfileCompliance.tsx
@@ -1,0 +1,3 @@
+export default function ProfileCompliance() {
+  return <h2>Profile & Compliance</h2>;
+}

--- a/src/pages/TimesheetsC404.tsx
+++ b/src/pages/TimesheetsC404.tsx
@@ -1,0 +1,3 @@
+export default function TimesheetsC404() {
+  return <h2>Timesheets</h2>;
+}

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,0 +1,26 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import C404Dashboard from '../features/c404/C404Dashboard';
+import AvailableShifts from '../pages/AvailableShifts';
+import MyBookings from '../pages/MyBookings';
+import TimesheetsC404 from '../pages/TimesheetsC404';
+import Messages from '../pages/Messages';
+import Payslips from '../pages/Payslips';
+import ProfileCompliance from '../pages/ProfileCompliance';
+
+export default function AppRoutes() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/c404/dashboard" element={<C404Dashboard />} />
+        <Route path="/available-shifts" element={<AvailableShifts />} />
+        <Route path="/my-bookings" element={<MyBookings />} />
+        <Route path="/my-bookings/:id" element={<MyBookings />} />
+        <Route path="/timesheets" element={<TimesheetsC404 />} />
+        <Route path="/messages" element={<Messages />} />
+        <Route path="/payslips" element={<Payslips />} />
+        <Route path="/profile-compliance" element={<ProfileCompliance />} />
+        <Route path="*" element={<C404Dashboard />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add C404 worker dashboard with cards, planner, and navigation
- provide typed mock data and API helpers for dashboard widgets
- wire up routes and basic placeholder pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dcda668ec8330b09f44b536ce7efd